### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,36 +6,36 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-TwoWire KEYWORD1
+TwoWire	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-beginTransmission KEYWORD2
-endTransmission KEYWORD2
-requestFrom KEYWORD2
-write KEYWORD2
-available KEYWORD2
-read KEYWORD2
-write KEYWORD2
-peek KEYWORD2
-flush KEYWORD2
+begin	KEYWORD2
+beginTransmission	KEYWORD2
+endTransmission	KEYWORD2
+requestFrom	KEYWORD2
+write	KEYWORD2
+available	KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
+peek	KEYWORD2
+flush	KEYWORD2
 
-twi_readFrom_timeout KEYWORD2
-twi_writeTo_timeout KEYWORD2
-twi_readFrom_wait KEYWORD2
-twi_writeTo_wait KEYWORD2
+twi_readFrom_timeout	KEYWORD2
+twi_writeTo_timeout	KEYWORD2
+twi_readFrom_wait	KEYWORD2
+twi_writeTo_wait	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-Wire KEYWORD2
+Wire	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-TWI_FREQ LITERAL1
+TWI_FREQ	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords